### PR TITLE
Default originalSize and originalUnit to 0 to avoid warning message

### DIFF
--- a/lib/Style/Normalizer/Border.php
+++ b/lib/Style/Normalizer/Border.php
@@ -25,8 +25,8 @@ class Border extends Normalizer
 		}
 		$matches = [];
 		preg_match('/([0-9]+)([a-z]+)\s+(solid|dashed|dotted|none)\s+(.+)?/ui', $ruleValue, $matches);
-		$originalSize = $matches[1];
-		$originalUnit = $matches[2];
+		$originalSize = $matches[1] = 0;
+		$originalUnit = $matches[2] = 0;
 		if (isset($matches[3])) {
 			$style = $matches[3];
 		} else {

--- a/lib/Style/Normalizer/Border.php
+++ b/lib/Style/Normalizer/Border.php
@@ -25,8 +25,8 @@ class Border extends Normalizer
 		}
 		$matches = [];
 		preg_match('/([0-9]+)([a-z]+)\s+(solid|dashed|dotted|none)\s+(.+)?/ui', $ruleValue, $matches);
-		$originalSize = $matches[1] = 0;
-		$originalUnit = $matches[2] = 0;
+		$originalSize = $matches[1] ?? 0;
+		$originalUnit = $matches[2] ?? 0;
 		if (isset($matches[3])) {
 			$style = $matches[3];
 		} else {


### PR DESCRIPTION
If the regular expression `preg_match('/([0-9]+)([a-z]+)\s+(solid|dashed|dotted|none)\s+(.+)?/ui', $ruleValue, $matches);` does not match, the variable `$matches` does not get initialized, which results in a warning message being generated.

Avoid warning message by defaulting `$matches[?]` to 0, when not initialized.